### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ scipy
 Pillow
 opencv-python
 pycocotools
+scikit-image


### PR DESCRIPTION
Needed for the visualization.

Otherwise, the following traceback occurs:
```
Traceback (most recent call last):
  File "inspect_coco.py", line 6, in <module>
    from utils import visualize
  File "/homes/xxx/cityscapes-to-coco-conversion/utils/visualize.py", line 16, in <module>
    from skimage.measure import find_contours
ModuleNotFoundError: No module named 'skimage
```